### PR TITLE
Added .postcss as a valid file extension

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,10 @@ exports.config = {
 
 Note that each of these files are always added to each component, so in most cases they shouldn't contain CSS because it'll get duplicated in each component. Instead, `injectGlobalPaths` should only be used for Sass variables, mixins and functions, but not contain any CSS.
 
+## Valid file extensions
+
+This plugin will only transpile files whose extensions are `.css`, `.pcss`, or `.postcss`.
+
 ## Related
 
 * [postcss](https://github.com/postcss/postcss)

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 
 export function usePlugin(fileName: string) {
-  return /(\.css|\.pcss)$/i.test(fileName);
+  return /(\.css|\.pcss|\.postcss)$/i.test(fileName);
 }
 
 export function getRenderOptions(opts: d.PluginOptions, sourceText: string, context: d.PluginCtx) {


### PR DESCRIPTION
I've seen `.css`, `.pcss`, and `.postcss` all used as file extensions for postcss files.  I added the latter to the list of valid extensions in `usePlugin`.

I also added documentation of the file extensions in the readme (I was trying to use the extension `.postcss` and couldn't figure out why nothing was working, until looking in the code).  I added it as an `h2`, but I'm not sure that it deserves an entire section all unto itself; I just wasn't sure where to put it.