### PR TITLE
fix: update type declarations, allow context to be undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export function postcss(opts: d.PluginOptions = {}): d.Plugin {
         return null;
       }
 
-      if (!context || !util.usePlugin(fileName)) {
+      if (!util.usePlugin(fileName)) {
         return null;
       }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,10 +16,10 @@ export function getRenderOptions(opts: d.PluginOptions, sourceText: string, cont
 
   const injectGlobalPaths = Array.isArray(opts.injectGlobalPaths) ? opts.injectGlobalPaths.slice() : [];
 
-  if (injectGlobalPaths.length > 0) {
+  if (context && injectGlobalPaths.length > 0) {
     // automatically inject each of these paths into the source text
     const injectText = injectGlobalPaths.map(injectGlobalPath => {
-      if (!path.isAbsolute(injectGlobalPath)) {
+      if (!path.isAbsolute(injectGlobalPath) && context.config.rootDir) {
         // convert any relative paths to absolute paths relative to the project root
         injectGlobalPath = path.join(context.config.rootDir, injectGlobalPath);
       }

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -45,6 +45,16 @@ describe('getRenderOptions', () => {
     expect(output.plugins).toHaveLength(0);
   });
 
+  it('should not break with undefined context', () => {
+    const input: d.PluginOptions = {
+      injectGlobalPaths: ['./my/global/variables.pcss']
+    };
+
+    expect(() => {
+      const output = util.getRenderOptions(input, undefined, undefined);
+    }).not.toThrow();
+  });
+
 });
 
 


### PR DESCRIPTION
~~This updates the type declarations to be in sync with @stencil/core~~. This allows context to be undefined, which allows importing 3rd party styles.

Fixes #15