### PR TITLE
updated to postcss 7.0.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test.watch": "jest --watch"
   },
   "dependencies": {
-    "postcss": "7.0.17"
+    "postcss": "^7.0.17"
   },
   "devDependencies": {
     "@types/jest": "^24.0.13",

--- a/package.json
+++ b/package.json
@@ -20,18 +20,18 @@
     "test.watch": "jest --watch"
   },
   "dependencies": {
-    "postcss": "6.0.20"
+    "postcss": "7.0.17"
   },
   "devDependencies": {
-    "@types/jest": "^22.2.0",
-    "@types/node": "^8.5.1",
-    "jest": "^22.4.2",
-    "np": "^2.20.1",
-    "rimraf": "^2.6.2",
-    "rollup": "^0.57.1",
-    "tslint": "^5.9.1",
-    "tslint-ionic-rules": "0.0.14",
-    "typescript": "^2.7.2"
+    "@types/jest": "^24.0.13",
+    "@types/node": "^12.0.7",
+    "jest": "^24.8.0",
+    "np": "^5.0.3",
+    "rimraf": "^2.6.3",
+    "rollup": "^1.14.3",
+    "tslint": "^5.17.0",
+    "tslint-ionic-rules": "0.0.21",
+    "typescript": "^3.5.1"
   },
   "repository": {
     "type": "git",

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -1,6 +1,6 @@
 export interface PluginOptions {
   injectGlobalPaths?: string[];
-  plugins?: Array<any>;
+  plugins?: any[];
 }
 
 export interface PluginTransformResults {
@@ -10,7 +10,7 @@ export interface PluginTransformResults {
 
 export interface RendererOptions {
   data: string;
-  plugins: Array<any>;
+  plugins: any[];
 }
 
 export interface PluginCtx {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "allowUnreachableCode": false,
     "alwaysStrict": true,
     "declaration": true,


### PR DESCRIPTION
Similar to https://github.com/ionic-team/stencil-postcss/pull/13 but also I've updated all dependancies, added missing jest dev dependancy and fixed linting issues.

I need to be merged so that I can use https://github.com/FullHuman/postcss-purgecss which uses a later version of postcss.

Once this is merged I can then create pull request for https://github.com/jagreehal/setup-examples