### PR TITLE
Add issue templating for version numbers

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!--
+NOTE:
+Before submitting an issue, please consult our docs -> https://stenciljs.com/
+-->
+
+**Stencil versions:**
+<!-- (run `npm list @stencil/core` from a terminal/cmd prompt and paste output below): -->
+```
+ @stencil/core@<version>
+ @stencil/postcss@<version>
+ @stencil/*@<version>
+```
+
+**I'm submitting a:**
+<!-- (check one with "x") -->
+[ ] bug report
+[ ] feature request
+[ ] support request => Please do not submit support requests here, use one of these channels: https://stencil-worldwide.herokuapp.com/ or https://forum.ionicframework.com/
+
+**Current behavior:**
+<!-- Describe how the bug manifests. -->
+
+**Expected behavior:**
+<!-- Describe what the behavior would be without the bug. -->
+
+**Steps to reproduce:**
+<!-- If you are able to illustrate the bug or feature request with an example, please provide steps to reproduce and if possible a demo
+-->
+
+**Related code or configs:**
+
+```tsx
+// insert any relevant code here
+```
+
+**Other information:**
+<!-- List any other information that is relevant to your issue. Stack traces, related issues, suggestions on how to fix, Stack Overflow links, forum links, etc. -->


### PR DESCRIPTION
Hi,

Looked through some issues and I think it will be helpful to have some version number right from the start of an Issue.

So I copied your Stencil template and added it here.