### PR TITLE
update autoprefixer import syntax

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ npm install autoprefixer @types/autoprefixer --save-dev
 ```ts
 import { Config } from '@stencil/core';
 import { postcss } from '@stencil/postcss';
-import * as autoprefixer from 'autoprefixer';
+import autoprefixer from 'autoprefixer';
 
 export const config: Config = {
   plugins: [


### PR DESCRIPTION
Using the current sample code on the readme I ran into this issue: https://github.com/ionic-team/stencil/issues/1043. Basically when autoprefixer enabled `esModuleInterop`, it broke the `import * as ` syntax. 

Updating the `readme` with the correct import syntax will prevent others from running into this same issue. 

