### PR TITLE
docs: Correct `import` for latest `autoprefixer`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ npm install autoprefixer @types/autoprefixer --save-dev
 ```ts
 import { Config } from '@stencil/core';
 import { postcss } from '@stencil/postcss';
-import * as autoprefixer from 'autoprefixer';
+import autoprefixer from 'autoprefixer';
 
 export const config: Config = {
   plugins: [


### PR DESCRIPTION
When following the docs for `@stencil/postcss` on a relatively barebones project (all I did was add `@stencil/sass` as well), I get a compiler error:

```
> stencil-1-8-7@0.0.1 build /Users/CDura/code/stencil-1-8-7
> stencil build --docs


[ ERROR ]  autoprefixer is not a function TypeError: autoprefixer is not a function at Object.<anonymous>
           (/Users/CDura/code/stencil-1-8-7/stencil.config.ts:31:23) at Module._compile
           (internal/modules/cjs/loader.js:955:30) at Object.require.extensions..ts
           (/Users/CDura/code/stencil-1-8-7/node_modules/@stencil/core/dist/sys/node/index.js:4817:16) at Module.load
           (internal/modules/cjs/loader.js:811:32) at Function.Module._load (internal/modules/cjs/loader.js:723:14) at
           Module.require (internal/modules/cjs/loader.js:848:19) at require (internal/modules/cjs/helpers.js:74:18) at
           requireConfigFile
           (/Users/CDura/code/stencil-1-8-7/node_modules/@stencil/core/dist/sys/node/index.js:4820:20) at
           loadConfigFile (/Users/CDura/code/stencil-1-8-7/node_modules/@stencil/core/dist/sys/node/index.js:4771:32)
           at NodeSystem.loadConfigFile
           (/Users/CDura/code/stencil-1-8-7/node_modules/@stencil/core/dist/sys/node/index.js:33404:16)
```

I'm guessing `autoprefixer` changed how they're exporting their members. Because removing the wildcard `*` fixed it for me.

Updating the docs so users don't bang their heads against the wall. :)