### PR TITLE
Handle dependency messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,9 @@ export function postcss(opts: d.PluginOptions = {}): d.Plugin {
               resolve(results);
             } else {
               results.code = postCssResults.css.toString();
+              results.dependencies = postCssResults.messages
+                .filter(message => message.type === 'dependency')
+                .map(dependency => dependency.file);
 
               // write this css content to memory only so it can be referenced
               // later by other plugins (autoprefixer)


### PR DESCRIPTION
This pull requests adds support for PostCSS `dependency` messages, which are used by plugins to register file dependencies. Documentation: https://github.com/postcss/postcss/blob/main/docs/guidelines/runner.md#3-dependencies

Note that there is also a `dir-dependency` message type but I am not sure how/if Stencil can support this.