### PR TITLE
fix: proper reason in diagnostics if postcss plugin failes

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -16,7 +16,7 @@ export function loadDiagnostic(context: d.PluginCtx, postcssError: any, filePath
     code: postcssError.status && postcssError.status.toString(),
     relFilePath: null,
     absFilePath: null,
-    messageText: postcssError.reason,
+    messageText: postcssError.reason || postcssError.message || JSON.stringify(postcssError),
     lines: []
   };
 


### PR DESCRIPTION
If a postcss plugin fails sometimes we end up with error that has no `reason` property only `message`
It would be nice to use that instead or fall back to the stringification of the error object. 
A hard to read error is still better than an undefined.
This PR aims to do just that

Before:
![image](https://user-images.githubusercontent.com/3637899/126177863-484a18b2-b109-4d32-bb59-cee1e4b4c508.png)


After:
![image](https://user-images.githubusercontent.com/3637899/126177722-ffb6d1d9-06c4-4d44-a41c-00d1f8e726db.png)
