### PR TITLE
chore: udpate postcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/postcss",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "MIT",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "autoprefixer": "^10.3.6",
-    "postcss": "~8.3.8"
+    "postcss": "~8.4.14"
   },
   "peerDependencies": {
     "@stencil/core": ">=2.0.0"


### PR DESCRIPTION
Fixes problems with the latest Tailwindcss version & the postcss Stencil is based on: https://github.com/tailwindlabs/tailwindcss/issues/8160#issuecomment-1113884418