### PR TITLE
Added option to use un-cached versions of unchanged input files. JIT working for i.e. TailwindCSS.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "autoprefixer": "^10.3.6",
+    "glob": "^8.0.3",
     "postcss": "~8.3.8"
   },
   "peerDependencies": {

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -3,6 +3,7 @@ export * from '@stencil/core/internal';
 export interface PluginOptions {
   injectGlobalPaths?: string[];
   plugins?: any[];
+  alwaysParseNonCachedCss?: boolean;
 }
 
 export interface RendererOptions {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import postCss from 'postcss';
 import { loadDiagnostic } from './diagnostics';
 import type * as d from './declarations';
 import * as util from './util';
+import path from 'path';
+import glob from 'glob';
 
 export function postcss(opts: d.PluginOptions = {}): d.Plugin {
   return {
@@ -70,6 +72,13 @@ export function postcss(opts: d.PluginOptions = {}): d.Plugin {
               // results.dependencies = postCssResults.messages
               //   .filter((message) => message.type === 'dir-dependency')
               //   .map((dependency) => () => dependency.file);
+              let dirDependencies: string[][] = postCssResults.messages
+                .filter((message) => message.type === "dir-dependency")
+                .map((dependencyGlob) => {
+                  const fileGlob = dependencyGlob.glob ? path.join(dependencyGlob.dir, dependencyGlob.glob) : path.join(dependencyGlob.dir, "**", "*");
+                  return glob.sync(fileGlob);
+                  });
+              results.dependencies.concat(...dirDependencies); // The dirDep endencies array is 2D, since each glob will resolve to a file list.
 
               // write this css content to memory only so it can be referenced
               // later by other plugins (autoprefixer)

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,21 +64,14 @@ export function postcss(opts: d.PluginOptions = {}): d.Plugin {
                 .filter((message) => message.type === 'dependency')
                 .map((dependency) => dependency.file);
 
-              // TODO(#38) https://github.com/ionic-team/stencil-postcss/issues/38
-              // determining how to pass back the dir-dependency message helps
-              // enable JIT behavior, such as Tailwind.
-              //
-              // Pseudocode:
-              // results.dependencies = postCssResults.messages
-              //   .filter((message) => message.type === 'dir-dependency')
-              //   .map((dependency) => () => dependency.file);
-              let dirDependencies: string[][] = postCssResults.messages
+              const dirDependencies: string[][] = postCssResults.messages
                 .filter((message) => message.type === "dir-dependency")
                 .map((dependencyGlob) => {
-                  const fileGlob = dependencyGlob.glob ? path.join(dependencyGlob.dir, dependencyGlob.glob) : path.join(dependencyGlob.dir, "**", "*");
-                  return glob.sync(fileGlob);
+                  const fileGlob: string = dependencyGlob.glob ? path.join(dependencyGlob.dir, dependencyGlob.glob)
+                                                               : path.join(dependencyGlob.dir, "**", "*");
+                  return glob.sync(fileGlob.replace(/\\/g, '/')); // Make sure that windows paths get transformed to POSIX style
                   });
-              results.dependencies.concat(...dirDependencies); // The dirDep endencies array is 2D, since each glob will resolve to a file list.
+              results.dependencies.concat(...dirDependencies); // The dirDependencies array is 2D, since each glob will resolve to a file list.
 
               // write this css content to memory only so it can be referenced
               // later by other plugins (autoprefixer)


### PR DESCRIPTION
This pull request is a solution to [Issue #38](https://github.com/ionic-team/stencil-postcss/issues/38).

`dir-dependency` messages will be parsed and with the help of the glob package, globs will resolve to file lists parsable by Stencil.

The parsing of `dir-dependency` messages happens in accordance with the recommendations set by the [PostCSS guides](https://github.com/postcss/postcss/blob/main/docs/guidelines/runner.md#31-rebuild-when-dependencies-change).

The change was tested in a Tailwind+Stencil integration, where JIt updates now work properly.