### PR TITLE
chore(ownership): move postcss plugin to stencil-community

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stencil/postcss",
+  "name": "@stencil-community/postcss",
   "version": "2.1.0",
   "license": "MIT",
   "main": "dist/index.cjs.js",

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,11 @@
-# @stencil/postcss
+# @stencil-community/postcss
 
 This package is used in order to integrate with postcss and all of its plugins.
 
 First, npm install within the project:
 
 ```
-npm install @stencil/postcss --save-dev
+npm install @stencil-community/postcss --save-dev
 ```
 
 Next, within the project's `stencil.config.ts` file, import the plugin and add
@@ -20,7 +20,7 @@ This plugin requires Node.js 14 or higher. For older Node versions, see the 1.x 
 #### stencil.config.ts
 ```ts
 import { Config } from '@stencil/core';
-import { postcss } from '@stencil/postcss';
+import { postcss } from '@stencil-community/postcss';
 import autoprefixer from 'autoprefixer';
 
 export const config: Config = {


### PR DESCRIPTION
this is the first commit necessary to move the postcss plugin to the
community model. it changes the name of the package to
`@stencil-community/postcss` (from `@stencil/postcss`).

the order of events is planned to be as follows:
1. (Done) move this repository over to the new stencil community org in github
2. (You are here) get this pr approved/landed
3. publish the package to the newly created `@stencil-community` npm org