### PR TITLE
fix: support v3 @stencil/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "postcss": "~8.3.8"
   },
   "peerDependencies": {
-    "@stencil/core": ">=2.0.0"
+    "@stencil/core": ">=2.0.0 || >=3.0.0"
   },
   "devDependencies": {
     "@ionic/prettier-config": "^2.0.0",


### PR DESCRIPTION
This invalid peerDepdendency value causes a type error when upgrading to stencil v3 as npm dedupes and uses a v2 `@stencil/core` package in a monorepo.