### PR TITLE
Do not write postcss changes back to in memory FS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,15 +71,8 @@ export function postcss(opts: d.PluginOptions = {}): d.Plugin {
               //   .filter((message) => message.type === 'dir-dependency')
               //   .map((dependency) => () => dependency.file);
 
-              // write this css content to memory only so it can be referenced
-              // later by other plugins (autoprefixer)
-              // but no need to actually write to disk
-              context.fs.writeFile(results.id, results.code, { inMemoryOnly: true }).then(() => {
-                resolve(results);
-              });
+              resolve(results);
             }
-
-            return results;
           })
           .catch((err: any) => {
             loadDiagnostic(context, err, fileName);


### PR DESCRIPTION
Currently, the transformed css file is written back to the in memory file system. In watch mode, this causes every rewritten file to be sent through postcss on any change. 

![image](https://github.com/stencil-community/stencil-postcss/assets/11861797/8a7715a6-eb59-44c6-938b-7b189ed4b4bc)

Not only does this make watch mode very slow, eventually, you run out of memory.

<details>
<summary>Out of memory example</summary>

```
[23:32.3]  generate lazy + source maps started ...

<--- Last few GCs --->

[29613:0x6462890]  3175587 ms: Mark-sweep 2043.5 (2076.5) -> 2040.0 (2076.7) MB, 467.9 / 0.0 ms  (average mu = 0.099, current mu = 0.014) allocation failure; scavenge might not succeed
[29613:0x6462890]  3176332 ms: Mark-sweep 2044.0 (2076.7) -> 2040.5 (2077.2) MB, 738.3 / 0.0 ms  (average mu = 0.045, current mu = 0.009) allocation failure; scavenge might not succeed


<--- JS stacktrace --->

FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
 1: 0xb6e500 node::Abort() [/home/george/.nvm/versions/node/v18.12.1/bin/node]
 2: 0xa7e632  [/home/george/.nvm/versions/node/v18.12.1/bin/node]
 3: 0xd47f20 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [/home/george/.nvm/versions/node/v18.12.1/bin/node]
 4: 0xd482c7 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [/home/george/.nvm/versions/node/v18.12.1/bin/node]
 5: 0xf25685  [/home/george/.nvm/versions/node/v18.12.1/bin/node]
 6: 0xf37b6d v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [/home/george/.nvm/versions/node/v18.12.1/bin/node]
 7: 0xf1226e v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/home/george/.nvm/versions/node/v18.12.1/bin/node]
 8: 0xf13637 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/home/george/.nvm/versions/node/v18.12.1/bin/node]
 9: 0xef480a v8::internal::Factory::NewFillerObject(int, v8::internal::AllocationAlignment, v8::internal::AllocationType, v8::internal::AllocationOrigin) [/home/george/.nvm/versions/node/v18.12.1/bin/node]
10: 0x12b7daf v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned long*, v8::internal::Isolate*) [/home/george/.nvm/versions/node/v18.12.1/bin/node]
11: 0x16e99f9  [/home/george/.nvm/versions/node/v18.12.1/bin/node]
error Command failed with signal "SIGABRT".
```
</details>

The comment explaining why this happens:
```
// write this css content to memory only so it can be referenced
// later by other plugins (autoprefixer)
// but no need to actually write to disk
```
Is incorrect, as later plugins use the returned result.

fixes: #34