### PR TITLE
docs: update autoprefixer attribute name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ exports.config = {
     postcss({
       plugins: [
         autoprefixer({
-          browsers: ['last 6 versions'],
+          overrideBrowserslist: ['last 6 versions'],
           cascade: false
         })
       ]


### PR DESCRIPTION
After the Autoprefixer updates the API to their plugin (a long time) there is another attribute name to `browsers`, we have `overrideBrowserslist`, This PR contemplates this change.

See [reference](https://github.com/postcss/autoprefixer/commit/6ed7c22bb6503968185935d807a61d6a593f352c)